### PR TITLE
fix: SQLAlchemy instance already registered

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,7 +12,7 @@ app.config["SQLALCHEMY_DATABASE_URI"] = f'sqlite:///{db_path}'
 app.config["SQLALCHEMY_ECHO"] = False
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
-db = SQLAlchemy(app)
+db = SQLAlchemy()
 
 from app import views
 from app import models


### PR DESCRIPTION
# Bug Fix
This fixes the following error: `RuntimeError: A 'SQLAlchemy' instance has already been registered on this Flask app. Import and use that instance instead.`

# Tutorial Fix (suggestion)

I was following this tutorial: https://codecapsules.io/docs/tutorials/build-flask-htmx-app/#running-our-app. If you own this, I suggest adding the following to that tutorial. I can see it's in this repo, but that is not reflected in the tutorial. It was causing this error: `RuntimeError: Working outside of application context.`

Thanks!

```
# in __init__.py
with app.app_context():
    db.create_all()
```

In https://codecapsules.io/docs/tutorials/build-flask-htmx-app/#running-our-app, it is simply:

```
# in __init__.py
db.create_all()
```